### PR TITLE
Added csrf_exempt argument for form_as_fieldsets.

### DIFF
--- a/betterforms/templates/partials/form_as_fieldsets.html
+++ b/betterforms/templates/partials/form_as_fieldsets.html
@@ -1,6 +1,8 @@
 {% block form_head %}
   {% if not no_head %}
-    {% csrf_token %}
+    {% if not csrf_exempt %}
+      {% csrf_token %}
+    {% endif %}
     {% if next %}
       <input type="hidden" name="next" value="{{ next }}">
     {% endif %}

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -139,3 +139,12 @@ This template does the following things.
       template.
   * for each field, renders the field using the template
     ``partials/field_as_div.html``
+
+If you want to output the form without the CSRF token (for example on a GET
+form), you can do so by passing in the csrf_exempt variable.
+
+.. code-block:: html
+
+    <form method="post">
+         {% include 'partials/form_as_fieldsets.html' csrf_exempt=True %}
+    </form>


### PR DESCRIPTION
This is useful for GET forms that don't need CSRF.
