### PR TITLE
Added cleaned_data to MultiForm.

### DIFF
--- a/betterforms/multiform.py
+++ b/betterforms/multiform.py
@@ -97,6 +97,13 @@ class MultiForm(object):
     def visible_fields(self):
         return [field for field in self if not field.is_hidden]
 
+    @property
+    def cleaned_data(self):
+        return OrderedDict(
+            (key, form.cleaned_data)
+            for key, form in self.forms.items()
+        )
+
 
 class MultiModelForm(MultiForm):
     """

--- a/docs/multiform.rst
+++ b/docs/multiform.rst
@@ -280,6 +280,11 @@ API Reference
 
     .. attribute:: is_bound
 
+    .. attribute:: cleaned_data
+
+        Returns an OrderedDict of the ``cleaned_data`` for each of the child
+        forms.
+
     .. method:: is_valid
 
     .. method:: non_field_errors

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -1,3 +1,8 @@
+try:
+    from collections import OrderedDict
+except ImportError:  # Python 2.6, Django < 1.7
+    from django.utils.datastructures import SortedDict as OrderedDict  # NOQA
+
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.views.generic import CreateView
@@ -129,6 +134,22 @@ class MultiFormTest(TestCase):
     def test_prefix(self):
         form = ErrorMultiForm(prefix='foo')
         self.assertEqual(form['errors'].prefix, 'errors__foo')
+
+    def test_cleaned_data(self):
+        form = UserProfileMultiForm({
+            'user-name': 'foo',
+            'profile-name': 'foo',
+        })
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data, OrderedDict([
+            ('user', {
+                'name': 'foo',
+            }),
+            ('profile', {
+                'name': 'foo',
+                'display_name': '',
+            }),
+        ]))
 
 
 class MultiModelFormTest(TestCase):


### PR DESCRIPTION
This should improve compatibility with things like
django.contrib.messages.views.SuccessMessageMixin.

It would be good to note that it's not actually useful for the success_message attribute because it uses old-style string formatting and everything is at least one level deep in the dictionary.  But at least it doesn't throw an error anymore.
