### PR TITLE
Handle None initial values more robustly.

### DIFF
--- a/betterforms/multiform.py
+++ b/betterforms/multiform.py
@@ -26,7 +26,9 @@ class MultiForm(object):
     form_classes = {}
 
     def __init__(self, *args, **kwargs):
-        self.initials = kwargs.pop('initial', {})
+        self.initials = kwargs.pop('initial', None)
+        if self.initials is None:
+            self.initials = {}
         self.forms = OrderedDict()
 
         for key, form_class in self.form_classes.items():

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -151,6 +151,10 @@ class MultiFormTest(TestCase):
             }),
         ]))
 
+    def test_handles_none_initial_value(self):
+        # Used to throw an AttributeError
+        UserProfileMultiForm(initial=None)
+
 
 class MultiModelFormTest(TestCase):
     def test_save(self):


### PR DESCRIPTION
I came across this doing something very ridiculous, but we should probably fix this.  I had already fixed this behavior for the MultiModelForm handling of the instance kwarg, because I came across that earlier, but I didn't catch this one.
