### PR TITLE
Required class is not in field.css_classes in default django forms

### DIFF
--- a/betterforms/templates/betterforms/field_as_div.html
+++ b/betterforms/templates/betterforms/field_as_div.html
@@ -2,7 +2,7 @@
 {% if field.is_hidden %}
   {{ field }}
 {% else %}
-<div class="{% if field.css_classes %}{{ field.css_classes }} {% endif %}{{ field.html_name }} formField">
+<div class="{% if field.css_classes %}{{ field.css_classes }} {% endif %}{{ field.html_name }} formField{% if field.field.required and not field.form.required_css_class %} required{% endif %}">
   {% if not field|is_checkbox %}
     {{ field.label_tag }}
   {% endif %}

--- a/betterforms/tests.py
+++ b/betterforms/tests.py
@@ -438,6 +438,33 @@ class TestFormRendering(TestCase):
             """,
         )
 
+    def test_fields_django_form_required(self):
+        class TestForm(forms.Form):
+            a = forms.CharField(label='A:')
+            b = forms.CharField(label='B:', required=False)
+
+        form = TestForm()
+
+        env = {
+            'form': form,
+            'no_head': True,
+            'fieldset_template_name': 'betterforms/fieldset_as_div.html',
+            'field_template_name': 'betterforms/field_as_div.html',
+        }
+        self.assertHTMLEqual(
+            render_to_string('betterforms/form_as_fieldsets.html', env),
+            """
+            <div class="a formField required">
+                <label for="id_a">A:</label>
+                <input id="id_a" name="a" type="text" />
+            </div>
+            <div class="b formField">
+                <label for="id_b">B:</label>
+                <input id="id_b" name="b" type="text" />
+            </div>
+            """,
+        )
+
     @unittest.expectedFailure
     def test_form_to_str(self):
         # TODO: how do we test this


### PR DESCRIPTION
This fixes what required-bug was supposed to fix
