### PR TITLE
Add name and html_name when form is prefixed.

### DIFF
--- a/betterforms/templates/betterforms/field_as_div.html
+++ b/betterforms/templates/betterforms/field_as_div.html
@@ -2,7 +2,7 @@
 {% if field.is_hidden %}
   {{ field }}
 {% else %}
-<div class="{% if field.css_classes %}{{ field.css_classes }} {% endif %}{{ field.html_name }} formField{% if field.field.required and not field.form.required_css_class %} required{% endif %}">
+<div class="{% if field.css_classes %}{{ field.css_classes }} {% endif %}{{ field.html_name }}{% if field.form.prefix %} {{ field.name }}{% endif %} formField{% if field.field.required and not field.form.required_css_class %} required{% endif %}">
   {% if not field|is_checkbox %}
     {{ field.label_tag }}
   {% endif %}

--- a/betterforms/tests.py
+++ b/betterforms/tests.py
@@ -567,6 +567,23 @@ class TestFormRendering(TestCase):
             """,
         )
 
+    def test_css_classes_when_form_has_prefix(self):
+        class TestForm(BetterForm):
+            name = forms.CharField()
+            label_suffix = ''
+
+        form = TestForm(prefix="prefix")
+        env = {'form': form, 'no_head': True}
+        self.assertHTMLEqual(
+            render_to_string('betterforms/form_as_fieldsets.html', env),
+            """
+            <div class="required prefix-name name formField">
+                <label for="id_prefix-name">Name</label>
+                <input type="text" id="id_prefix-name" name="prefix-name" />
+            </div>
+            """
+        )
+
 
 class ChangeListModel(models.Model):
     field_a = models.CharField(max_length=255)


### PR DESCRIPTION
This helps to not break the design when you have to add a prefix to a form.  But, if you want to target a specific field, you still can use the prefixed name.
