### PR TITLE
Add formset_as_fieldsets template and tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 1.2.0 (not yet released)
 ------------------------
 
+  - (Feature) Add partial template for rendering formsets [Scott Clark, #18]
 
 1.1.0 (2014-08-04)
 ------------------

--- a/betterforms/templates/betterforms/formset_as_fieldsets.html
+++ b/betterforms/templates/betterforms/formset_as_fieldsets.html
@@ -1,0 +1,31 @@
+{% block form_head %}
+  {% if not no_head %}
+    {% if not csrf_exempt %}
+      {% csrf_token %}
+    {% endif %}
+  {% endif %}
+{% endblock %}
+
+{% block form_body %}
+  {% with formset=form %}
+    <div class="formSet {{ formset.prefix }}">
+    {{ formset.management_form }}
+    {{ formset.non_form_errors }}
+    {% for form in formset.forms %}
+      <div class="formSetForm {{ form.prefix }}">
+        {{ form.non_field_errors }}
+        {# Hack to allow recursive template inclusion #}
+        {% with fieldset_template_name="betterforms/fieldset_as_div.html" field_template_name="betterforms/field_as_div.html" %}
+          {% for thing in form %}
+            {% if thing.is_fieldset %}
+              {% include fieldset_template_name with fieldset=thing %}
+            {% else %}
+              {% include field_template_name with field=thing %}
+            {% endif %}
+          {% endfor %}
+        {% endwith %}
+      </div>
+    {% endfor %}
+    </div>
+  {% endwith %}
+{% endblock %}

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -177,3 +177,11 @@ convenient class attribute on the :class:`BetterForm` and
     #18134`_.
 
 .. _Django bug #18134: https://code.djangoproject.com/ticket/18134
+
+Betterforms also provides a partial template for rendering formsets.
+``betterforms/formset_as_fieldsets.html`` will render the management
+form for the formset as well as wrap each individual form in a ``div``
+containing the class attributes of ``formSetForm`` and the unique
+prefix value of each form. Form fields, including additional fields
+for deleting and ordering the forms within the formset, will be
+rendered using the ``betterforms/field_as_div.html`` template.

--- a/tests/tests/forms.py
+++ b/tests/tests/forms.py
@@ -4,6 +4,8 @@ except ImportError:  # Python 2.6, Django < 1.7
     from django.utils.datastructures import SortedDict as OrderedDict  # NOQA
 
 from django import forms
+from django.forms.formsets import formset_factory
+from django.forms.models import modelformset_factory
 from django.contrib.admin import widgets as admin_widgets
 from django.core.exceptions import ValidationError
 
@@ -66,9 +68,15 @@ class NeedsFileField(MultiForm):
 
 
 class BadgeForm(forms.ModelForm):
+
     class Meta:
         model = Badge
         fields = ('name', 'color',)
+
+    # self.label_suffix has to be declared with form instantiation per Django 1.6
+    def __init__(self, *args, **kwargs):
+        super(BadgeForm, self).__init__(*args, **kwargs)
+        self.label_suffix = ''
 
 
 class BadgeMultiForm(MultiModelForm):
@@ -76,6 +84,17 @@ class BadgeMultiForm(MultiModelForm):
         'badge1': BadgeForm,
         'badge2': BadgeForm,
     }
+
+BadgeFormSet = formset_factory(BadgeForm, extra=2)
+
+BadgeDeleteFormSet = formset_factory(BadgeForm, can_delete=True, extra=2)
+
+BadgeOrderFormSet = formset_factory(BadgeForm, can_order=True, extra=2)
+
+try:
+    BadgeModelFormSet = modelformset_factory(Badge, form=BadgeForm, extra=2)
+except PendingDeprecationWarning:
+    BadgeModelFormSet = modelformset_factory(Badge, form=BadgeForm, fields='__all__', extra=2)
 
 
 class NonModelForm(forms.Form):


### PR DESCRIPTION
This creates a partial template which allows for ease of
rendering formsets. The template outputs the management
form, and wraps each form in a div with appropriate form
prefix class attributes.
