### PR TITLE
SortForm fixes

### DIFF
--- a/betterforms/changelist.py
+++ b/betterforms/changelist.py
@@ -312,7 +312,7 @@ class SortFormBase(BetterForm):
 
     def __init__(self, *args, **kwargs):
         super(SortFormBase, self).__init__(*args, **kwargs)
-        self.headers = HeaderSet(self, self.HEADERS)
+        self.headers = self.HeaderSetClass(self, self.HEADERS)
 
     def clean_sorts(self):
         cleaned_data = self.cleaned_data

--- a/betterforms/changelist.py
+++ b/betterforms/changelist.py
@@ -18,8 +18,15 @@ from .forms import BetterForm
 
 def construct_querystring(data, **kwargs):
     params = copy.copy(data)
-    params.update(kwargs)
-    return urlencode(params)
+
+    # We can't call update here because QueryDict extends rather than replaces.
+    for key, value in kwargs.items():
+        params[key] = value
+
+    if hasattr(params, 'urlencode'):
+        return params.urlencode()
+    else:
+        return urlencode(params)
 
 
 class IterDict(OrderedDict):


### PR DESCRIPTION
This does the following things:

* Makes this actually work with QueryDicts (did it work before?)
* Extracted out the SortFormBase so that I could use this with django-haystack.
* Made it actually use HeaderSetClass

ping @pipermerriam 