### PR TITLE
[WIP] [Due October] Remove Django <1.7 and Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
   - DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.7.x.zip
 matrix:
   include:
-    - python: "2.6"
-      env: DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
     - python: "2.7"
       env: DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.4.x.zip
 install:

--- a/betterforms/changelist.py
+++ b/betterforms/changelist.py
@@ -4,11 +4,9 @@ from django import forms
 from django.forms.forms import pretty_name
 from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.db.models import Q
-try:
-    from collections import OrderedDict
-except ImportError:
-    # Support for Python < 2.6
-    from django.utils.datastructures import SortedDict as OrderedDict
+
+from collections import OrderedDict
+
 from django.utils import six
 from django.utils.six.moves import reduce
 from django.utils.http import urlencode

--- a/betterforms/forms.py
+++ b/betterforms/forms.py
@@ -12,11 +12,9 @@ except ImportError:
     from django.forms.util import ErrorDict
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.template.loader import render_to_string
-try:
-    from collections import OrderedDict
-except ImportError:
-    # Support for Python < 2.6
-    from django.utils.datastructures import SortedDict as OrderedDict
+
+from collections import OrderedDict
+
 import six  # Django six is buggy with Django < 1.5
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/betterforms/multiform.py
+++ b/betterforms/multiform.py
@@ -1,10 +1,7 @@
 from itertools import chain
 from operator import add
 
-try:
-    from collections import OrderedDict
-except ImportError:  # Python 2.6, Django < 1.7
-    from django.utils.datastructures import SortedDict as OrderedDict  # NOQA
+from collections import OrderedDict
 
 try:
     from django.forms.utils import ErrorDict, ErrorList

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Topic :: Internet :: WWW/HTTP',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
     ],

--- a/tests/tests/forms.py
+++ b/tests/tests/forms.py
@@ -1,7 +1,4 @@
-try:
-    from collections import OrderedDict
-except ImportError:  # Python 2.6, Django < 1.7
-    from django.utils.datastructures import SortedDict as OrderedDict  # NOQA
+from collections import OrderedDict
 
 from django import forms
 from django.contrib.admin import widgets as admin_widgets

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -1,7 +1,4 @@
-try:
-    from collections import OrderedDict
-except ImportError:  # Python 2.6, Django < 1.7
-    from django.utils.datastructures import SortedDict as OrderedDict  # NOQA
+from collections import OrderedDict
 
 from django.test import TestCase
 from django.test.client import RequestFactory

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist=
-    py26-dj14,
     py27-dj14,
     py27-dj15,
     py27-dj16,
@@ -64,14 +63,6 @@ deps =
 basepython=python3.3
 deps =
   https://github.com/django/django/archive/stable/1.7.x.zip#egg=Django
-  # https://bitbucket.org/hpk42/tox/issue/13/tox-should-reuse-tests_require
-  mock
-  six
-
-[testenv:py26-dj14]
-basepython=python2.6
-deps =
-  Django==1.4.8
   # https://bitbucket.org/hpk42/tox/issue/13/tox-should-reuse-tests_require
   mock
   six


### PR DESCRIPTION
Running tox will cause an error in the Python 2.6 configuration on distributions using Python 3 tox. See for the bug report here: https://bugs.launchpad.net/ubuntu/+source/python-virtualenv/+bug/1398059

It will soon be two years since the EOL Python 2.6 release. In addition Travis isn't actually running the tests against Python 2.6, only 2.7. For these reasons I think Python 2.6 support should be dropped.
