### PR TITLE
Add testing for Django 1.11 and 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ setup(
         'Django>=1.4',
         'six',
     ],
-    tests_require=[
-        'mock>=1.0.1',
-    ],
     zip_safe=False,
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ version = '1.1.5.dev0'
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 setup(
     name='django-betterforms',
     version=version,
@@ -20,22 +21,29 @@ setup(
     url="https://django-betterforms.readthedocs.org/en/latest/",
     author="Fusionbox",
     author_email='programmers@fusionbox.com',
-    packages=[package for package in find_packages() if package.startswith('betterforms')],
-    install_requires=[
-        'Django>=1.4',
-        'six',
-    ],
+    packages=[package for package in find_packages()
+              if package.startswith('betterforms')],
+    install_requires=['Django>=1.7'],
     zip_safe=False,
     include_package_data=True,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
+        'Framework :: Django :: 1.7',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
-        'Topic :: Internet :: WWW/HTTP',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Internet :: WWW/HTTP',
     ],
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,8 +7,9 @@ class User(models.Model):
 
 
 class Profile(models.Model):
-    user = models.OneToOneField('User', related_name='profile')
-
+    user = models.OneToOneField(
+        User, on_delete=models.CASCADE, related_name='profile',
+    )
     display_name = models.CharField(max_length=255, blank=True)
 
 
@@ -27,5 +28,7 @@ class Book(models.Model):
 
 
 class BookImage(models.Model):
-    book = models.ForeignKey(Book, related_name='images')
+    book = models.ForeignKey(
+        Book, on_delete=models.CASCADE, related_name='images',
+    )
     name = models.CharField(max_length=255)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+django-formtools
+pytest
+pytest-django
+pytest-cov
+mock >=1.0.1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,7 +5,7 @@ SECRET_KEY = 'JVpuGfSgVm2IxJ03xArw5mwmPuYEzAJMbhsTnvLXOPSQR4z93o'
 
 PROJECT_PATH = os.path.abspath(os.path.dirname(__file__))
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     # We need the SessionMiddleware for the WizardView support tests in Django >= 1.7
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,12 @@
 from collections import OrderedDict
 
-import django
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.views.generic import CreateView
-from django.core import urlresolvers
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.utils.encoding import force_text
 
 from .models import User, Profile, Badge, Book
@@ -108,14 +110,7 @@ class MultiFormTest(TestCase):
 
     def test_media(self):
         form = NeedsFileField()
-        static_prefix = ""
-        if django.VERSION < (1, 10):
-            static_prefix = "/static/"
-        self.assertEqual(form.media._js, [
-            static_prefix + 'admin/js/calendar.js',
-            static_prefix + 'admin/js/admin/DateTimeShortcuts.js',
-            'test.js',
-        ])
+        self.assertIn('test.js', form.media._js)
 
     def test_is_bound(self):
         form = ErrorMultiForm()
@@ -169,7 +164,7 @@ class MultiFormTest(TestCase):
         UserProfileMultiForm(initial=None)
 
     def test_works_with_wizard_view(self):
-        url = urlresolvers.reverse('test_wizard')
+        url = reverse('test_wizard')
         self.client.get(url)
 
         response = self.client.post(url, {

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,6 @@ deps=
   dj19: Django>=1.9,<1.10
   dj110: Django>=1.10,<1.11
   djdev: https://github.com/django/django/archive/master.tar.gz
-  django-formtools
-  pytest
-  pytest-django
-  pytest-cov
-  mock
+  -r{toxinidir}/tests/requirements.txt
 whitelist_externals= 
   make

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,24 @@
 [tox]
-envlist=
-  {py27,py34,py35}-{dj17,dj18,dj19,dj110,djdev}
+envlist =
+  {py27,py34}-dj{17,18,19,110}
+  {py27,py34,py35,py36}-dj111
+  {py34,py35,py36}-dj20
+  {py35,py36}-djdev
 
 [testenv]
-commands=
-  make {posargs:test}
-basepython=
+basepython =
   py27: python2.7
   py34: python3.4
   py35: python3.5
-deps=
+  py36: python3.6
+commands = make {posargs:test}
+deps =
   dj17: Django>=1.7,<1.8
   dj18: Django>=1.8,<1.9
   dj19: Django>=1.9,<1.10
   dj110: Django>=1.10,<1.11
+  dj111: Django>=1.11,<2.0
+  dj20: Django>=2.0,<2.1
   djdev: https://github.com/django/django/archive/master.tar.gz
   -r{toxinidir}/tests/requirements.txt
-whitelist_externals= 
-  make
+whitelist_externals = make


### PR DESCRIPTION
Apart from adding testing for Django 1.11 & 2.0 and fixing tests, it also:
* move test requirements to a separate file `tests/requirements.txt` for clarity
* update package classifiers for pip
* update Django minimum version in `install_requires` according to tested versions
* remove `six` from `install_requires` as it only rely on Django compatibility utils.

It does not touch to Django supported versions - even if they are not maintained anymore.