### PR TITLE
multiline setuptools error fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@
 from setuptools import setup, find_packages
 import os
 
-__doc__ = """
-App for Django featuring improved form base classes.
-"""
-
 version = '1.2.1.dev0'
 
 
@@ -16,7 +12,7 @@ def read(fname):
 setup(
     name='django-betterforms',
     version=version,
-    description=__doc__,
+    description='App for Django featuring improved form base classes.',
     long_description=read('README.rst'),
     url="https://django-betterforms.readthedocs.org/en/latest/",
     author="Fusionbox",


### PR DESCRIPTION
The string contains "/n" like it is
Since SetupTools 51.3.0+  its not possible and error is raised.