### PR TITLE
Updated docstring to remove newline characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,7 @@
 from setuptools import setup, find_packages
 import os
 
-__doc__ = """
-App for Django featuring improved form base classes.
-"""
+__doc__ = """App for Django featuring improved form base classes."""
 
 version = '1.2.1.dev0'
 


### PR DESCRIPTION
Updated the setup.py doctring to remove the newline characters that were present. This is in reference to this pull request: https://github.com/fusionbox/django-betterforms/pull/61. Instead of removing __doc__ entirely, the docstring was put on one line to prevent errors with SetupTools.

Since at least 2018, SetupTools does not support newlines, as described in this issue https://github.com/pypa/setuptools/issues/1390.