### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/betterforms/__init__.py
+++ b/betterforms/__init__.py
@@ -1,1 +1,3 @@
-__version__ = __import__('pkg_resources').get_distribution('django-betterforms').version
+from importlib.metadata import version
+
+__version__ = version('django-betterforms')


### PR DESCRIPTION
Add support for modern pythons

`pkg_resources` is deprecated and is replaced by `importlib.metadata` module, which is part of the standard library